### PR TITLE
Promise free homework implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,42 @@
 'use strict'
 
-module.exports = downloadPackages
+const request = require('request');
+const cheerio = require('cheerio');
+const { exec } = require('child_process');
+
+let finishedCallback;
+let downloadCount = 0;
+let targetCount = 0;
 
 function downloadPackages (count, callback) {
-
+  finishedCallback = callback;
+  targetCount = count;
+  getPackageNames(count, 0);
 }
+
+function getPackageNames (packageCount, offset) {
+  // TODO: npm returns 36 per page.  If count > 36, get multiple pages
+  request('https://www.npmjs.com/browse/depended?offset=' + offset, function (error, response, html) {
+    if (!error && response.statusCode == 200) {
+      const npmDependencyHtml = cheerio.load(html);
+      npmDependencyHtml('a.name').each(function(i, element){
+        const packageName = npmDependencyHtml(this).text();
+        if(i < packageCount) {
+          downloadPackage(packageName);
+        }
+      });
+    }
+  });
+}
+
+function downloadPackage(packageName) {
+  // make a CLI call to get the tarball url, cURL that url, and unpack:
+  const execCommand = `mkdir -p packages/${packageName}; npm v ${packageName} dist.tarball | xargs curl | tar -xz --directory packages/${packageName}/ --strip 1`;
+  exec(execCommand, (err, stdout, stderr) => {
+    if(++downloadCount == targetCount) {
+      finishedCallback();
+    }
+  });
+}
+
+module.exports = downloadPackages

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "scripts": {
     "test": "node test.js"
   },
-  "dependencies": {},
+  "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
+    "htmlparser2": "^3.9.2",
+    "request": "^2.81.0"
+  },
   "devDependencies": {
     "get-folder-size": "~1.0.0",
     "tape": "~4.6.0",


### PR DESCRIPTION
Super-simple, but it gets the tests to pass.  Now that this works, I'll write a more elegant Promise-based solution next...

Packages used:
‘request’ to scrape the npm webpage
‘cheerio’ to parse the list of package names from the html
‘exec’ to create a command-line shortcut to get the package url, curl
the tarball, and extract it to the requested directory

To make it better: handle package counts higher than 36…
To make it better still: add Promises.

☮